### PR TITLE
Enable media stream access by default

### DIFF
--- a/common/src/main/java/com/cinemamod/mcef/CefUtil.java
+++ b/common/src/main/java/com/cinemamod/mcef/CefUtil.java
@@ -85,7 +85,9 @@ final class CefUtil {
         String[] cefSwitches = new String[]{
                 "--autoplay-policy=no-user-gesture-required",
                 "--disable-web-security",
-                "--enable-widevine-cdm" // https://canary.discord.com/channels/985588552735809696/992495232035868682/1151704612924039218
+                "--enable-widevine-cdm", // https://canary.discord.com/channels/985588552735809696/992495232035868682/1151704612924039218
+                "--enable-media-stream",
+                "--use-fake-ui-for-media-stream",
                 // TODO: should probably make this configurable
                 //       based off this page: https://magpcss.org/ceforum/viewtopic.php?f=6&t=11672
                 //       it seems the solution to the white screen is to add the "--disable-gpu" switch


### PR DESCRIPTION
## Summary
- allow camera and microphone by default via CEF switches

## Testing
- `./gradlew build` *(fails: Could not create an instance of type net.minecraftforge.gradle.userdev.DependencyManagementExtension)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c43f3150832aa76175226debe0fc